### PR TITLE
Fixed LDAP_USE_LDAP_GROUPS conditionals and added LDAP_GROUPS_SEARCH_BASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,13 @@ LDAP_ATTRIBUTES_MAP = {
 ### groups mapping to django's groups
 
 First parameter of this group enables to use LDAP group binding or disable it to use local database groups only. A the first release of this module does have this parameter, for reverse compatibility, if this parameter does not exists, it is considered true. If it is configured to false, other parameters of this group wont be used nor checked.
+If LDAP_GROUPS_SEARCH_BASE is not defined LDAP_SEARCH_BASE will be used as base for group lookup.
 As django defines 2 special rights outside of the use of groups, the module can bind specific group membership to those 2 special attributes in addition to classical groups binding.
 If superuser and staff parameters are not present, not a list or an empty list, those parameters are skipped. This way, you can use LDAP groups for "classical groups" and define manually in the database who will be superuser or staff user.
 
 ```python
 LDAP_USE_LDAP_GROUPS = True
+LDAP_GROUPS_SEARCH_BASE = "dc=domain,dc=local"
 LDAP_GROUPS_SEARCH_FILTER = "(&(objectClass=group))"
 LDAP_GROUP_MEMBER_ATTRIBUTE = "member"
 LDAP_SUPERUSER_GROUPS = ["CN=admin,dc=domain,dc=local", ]

--- a/django_auth_ldap3_ad/auth.py
+++ b/django_auth_ldap3_ad/auth.py
@@ -48,8 +48,9 @@ class LDAP3ADBackend(object):
 
         # as first release of the module does not have this parameter, default is to set it true to keep the same
         # comportment after updates.
-        LDAP_USE_LDAP_GROUPS = False
-        if not hasattr(settings, 'LDAP_USE_LDAP_GROUPS') or not isinstance(settings.LDAP_USE_LDAP_GROUPS, bool):
+        if hasattr(settings, 'LDAP_USE_LDAP_GROUPS') and isinstance(settings.LDAP_USE_LDAP_GROUPS, bool):
+            LDAP_USE_LDAP_GROUPS = settings.LDAP_USE_LDAP_GROUPS
+        else:
             LDAP_USE_LDAP_GROUPS = True
 
         if LDAP_USE_LDAP_GROUPS and not (hasattr(settings, 'LDAP_GROUPS_SEARCH_FILTER')

--- a/django_auth_ldap3_ad/auth.py
+++ b/django_auth_ldap3_ad/auth.py
@@ -113,7 +113,9 @@ class LDAP3ADBackend(object):
                         grp.save()
 
                     # then re-fill
-                    con.search(settings.LDAP_SEARCH_BASE, settings.LDAP_GROUPS_SEARCH_FILTER,
+                    con.search(settings.LDAP_GROUPS_SEARCH_BASE if hasattr(settings, 'LDAP_GROUPS_SEARCH_BASE')
+                               else settings.LDAP_SEARCH_BASE,
+                               settings.LDAP_GROUPS_SEARCH_FILTER,
                                attributes=['cn', settings.LDAP_GROUP_MEMBER_ATTRIBUTE])
                     if len(con.response) > 0:
                         for resp in con.response:

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
     ],
-    install_requires=["Django>=1.8", "ldap3>=0.9.8.*"],
+    install_requires=["Django>=1.8", "ldap3>=0.9.8"],
 )


### PR DESCRIPTION
This pull request includes a fixed for LDAP_USE_LDAP_GROUPS. The real settings.LDAP_USE_LDAP_GROUPS was not being assigned to the LDAP_USE_LDAP_GROUPS variable.

It also includes a commit that adds the LDAP_GROUPS_SEARCH_BASE option, so you can define a different search base to query for the groups. Useful for large databases or with certain schemas.
