### PR TITLE
Fixed identation error when generating LDAP_GROUPS_SEARCH_FILTER

### DIFF
--- a/django_auth_ldap3_ad/auth.py
+++ b/django_auth_ldap3_ad/auth.py
@@ -77,9 +77,9 @@ class LDAP3ADBackend(object):
             # all_ldap_groups.append("(distinguishedName={0})".format(group))
             all_ldap_groups.append("(distinguishedName={0})".format(group))
 
-            if len(all_ldap_groups) > 0:
-                settings.LDAP_GROUPS_SEARCH_FILTER = "(&{0}(|{1}))".format(settings.LDAP_GROUPS_SEARCH_FILTER,
-                                                                           "".join(all_ldap_groups))
+        if len(all_ldap_groups) > 0:
+            settings.LDAP_GROUPS_SEARCH_FILTER = "(&{0}(|{1}))".format(settings.LDAP_GROUPS_SEARCH_FILTER,
+                                                                       "".join(all_ldap_groups))
         # end
 
 


### PR DESCRIPTION
There is an indentation error in commit https://github.com/Lucterios2/django_auth_ldap3_ad/commit/3c4530ec671f475a61ea9e39ec3ed17eb2336938 that is not present in the code provided https://github.com/Lucterios2/django_auth_ldap3_ad/commit/ce24d4687f85ed12a0c4c796022ae7dcb3ff38e3, causing problems when generating LDAP_GROUPS_SEARCH_FILTER dinamically.

This commit fixes it.
