### PR TITLE
Keep users in local groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ If this parameter is set, the module takes care that each connected user is memb
 LDAP_MIN_GROUPS = ["MyDjangoGroup", ]
 ```
 
+### kept users in local groups
+
+If this parameter is set, the module will kept users in these locally-defined groups. Otherwise, every group membership is refreshed (removed and readded) when a user authenticates. 
+
+```python
+LDAP_IGNORED_LOCAL_GROUPS = ["MyLocalDjangoGroup", ]
+```
 
 ### groups mapping to django's groups
 


### PR DESCRIPTION
Added settings parameter to allow developers defining a list of local django groups that are not refreshed (removed and, if it exists in the LDAP, readded) each time an user authenticates.

Without this patch, when using a mix of LDAP groups and Django groups, a user will lose their local group membership everytime they authenticate.
