### PR TITLE
Fix for #8 - only first letters extracted from ldap query

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ LDAP_ATTRIBUTES_MAP = {
 }
 ```
 
+### changing username field in user model
+
+Which user model field should be used as user login. Default: `username`.
+
+```python
+LDAP_USER_MODEL_USERNAME_FIELD = 'email'
+```
+
+Make sure field is mapped to LDAP attribute in `LDAP_ATTRIBUTES_MAP`.
+
 ### minimal group membership
 
 If this parameter is set, the module takes care that each connected user is member of this groups whereas you want to use LDAP groups or not.

--- a/django_auth_ldap3_ad/auth.py
+++ b/django_auth_ldap3_ad/auth.py
@@ -306,5 +306,9 @@ class LDAP3ADBackend(object):
                 if settings.LDAP_ATTRIBUTES_MAP[attr] in attributes \
                         and len(attributes[settings.LDAP_ATTRIBUTES_MAP[attr]]) >= 1 \
                         and hasattr(user, attr):
-                    setattr(user, attr, attributes[settings.LDAP_ATTRIBUTES_MAP[attr]][0])
+                    if isinstance(attributes[settings.LDAP_ATTRIBUTES_MAP[attr]], str):
+                        attribute_value = attributes[settings.LDAP_ATTRIBUTES_MAP[attr]]
+                    else:
+                        attribute_value = attributes[settings.LDAP_ATTRIBUTES_MAP[attr]][0]
+                    setattr(user, attr, attribute_value)
         user.save()

--- a/django_auth_ldap3_ad/auth.py
+++ b/django_auth_ldap3_ad/auth.py
@@ -156,7 +156,8 @@ class LDAP3ADBackend(object):
                 user_model.bu = lambda: None
                 try:
                     # try to retrieve user from database and update it
-                    usr = user_model.objects.get(username__iexact=username)
+                    username_field = getattr(settings, 'LDAP_USER_MODEL_USERNAME_FIELD', 'username') 
+                    usr = user_model.objects.get(**{"{0}__iexact".format(username_field): username})
                 except user_model.DoesNotExist:
                     # user does not exist in database already, create it
                     usr = user_model()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-auth-ldap3-ad',
-    version='1.5.0',
+    version='1.5.2',
     packages=['django_auth_ldap3_ad'],
     url='https://github.com/Lucterios2/django_auth_ldap3_ad',
     license='GPL V3',


### PR DESCRIPTION
Sometimes ldap search results are strings instead of arrays of strings.

Fixes Lucterios2/django_auth_ldap3_ad#8