### PR TITLE
Added possibility of setting LDAP authentication method

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ LDAP_BIND_PASSWORD = "pass"
 
 You can also use LDAP_BIND_PWD for the bind password. `LDAP_BIND_PASSWORD` will be replaced with '****' in debug views like `django_debug_toolbar` while `LDAP_BIND_PWD` will not.
 
+
+### LDAP Authentication parameter
+
+Optional parameter.
+If you want to change method of authorization with your LDAP from SIMPLE to any else (FIRST, SYNC, SIMPLE, NTLM), you can do it by setting parameter in settings.
+
+```python
+from ldap3 import NTLM
+LDAP_AUTHENTICATION = NTLM
+```
+
 ### search parameters
 
 Mandatory parameters.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-auth-ldap3-ad',
-    version='1.6.21',
+    version='1.6.22',
     packages=['django_auth_ldap3_ad'],
     url='https://github.com/Lucterios2/django_auth_ldap3_ad',
     license='GPL V3',


### PR DESCRIPTION
Hi,
I've added possibility to change LDAP auth method.
In the base code SIMPLE auth is hardcoded and I've added option to change it, but it's optional, if it isn't set it still defaults to SIMPLE.