### PR TITLE
Use the correct now()

### DIFF
--- a/django_auth_ldap3_ad/auth.py
+++ b/django_auth_ldap3_ad/auth.py
@@ -29,6 +29,7 @@ from ldap3 import Server, ServerPool, Connection, FIRST, SYNC, SIMPLE, NTLM
 from six import string_types
 from django.core.exceptions import ObjectDoesNotExist, ImproperlyConfigured
 from datetime import datetime
+from django.utils import timezone
 import logging
 from django.contrib.auth.signals import user_logged_in
 
@@ -168,7 +169,7 @@ class LDAP3ADBackend(object):
                 # update existing or new user with LDAP data
                 self.update_user(usr, user_attribs)
                 usr.set_password(password)
-                usr.last_login = datetime.now()
+                usr.last_login = timezone.now()
                 usr.save()
 
                 # if we want to use LDAP group membership:

--- a/django_auth_ldap3_ad/auth.py
+++ b/django_auth_ldap3_ad/auth.py
@@ -28,7 +28,6 @@ from django.contrib.auth.models import Group
 from ldap3 import Server, ServerPool, Connection, FIRST, SYNC, SIMPLE, NTLM
 from six import string_types
 from django.core.exceptions import ObjectDoesNotExist, ImproperlyConfigured
-from datetime import datetime
 from django.utils import timezone
 import logging
 from django.contrib.auth.signals import user_logged_in
@@ -133,7 +132,7 @@ class LDAP3ADBackend(object):
     """
 
     def authenticate(self, request, username=None, password=None):
-        logger.info("AUDIT BEGIN LOGIN PROCESS FOR: %s AT %s" % (username, datetime.now()))
+        logger.info("AUDIT BEGIN LOGIN PROCESS FOR: %s" % (username,))
         if username is None or username == '':
             return None
 
@@ -148,7 +147,7 @@ class LDAP3ADBackend(object):
             # the LDAP checks the password with it's algorithm and the active state of the user in one test
             con = Connection(LDAP3ADBackend.pool, user=user_dn, password=password)
             if con.bind():
-                logger.info("AUDIT SUCCESS LOGIN FOR: %s AT %s" % (username, datetime.now()))
+                logger.info("AUDIT SUCCESS LOGIN FOR: %s" % (username,))
                 user_model = get_user_model()
 
                 """
@@ -207,7 +206,7 @@ class LDAP3ADBackend(object):
                                 settings.LDAP_GROUPS_SEARCH_FILTER,
                                 "".join(all_ldap_groups))
 
-                    logger.info("AUDIT LOGIN FOR: %s AT %s USING LDAP GROUPS" % (username, datetime.now()))
+                    logger.info("AUDIT LOGIN FOR: %s USING LDAP GROUPS" % (username,))
                     # check for groups membership
                     # first cleanup
                     alter_superuser_membership = False
@@ -223,7 +222,7 @@ class LDAP3ADBackend(object):
                         alter_staff_membership = True
 
                     usr.save()
-                    logger.info("AUDIT LOGIN FOR: %s AT %s CLEANING OLD GROUP MEMBERSHIP" % (username, datetime.now()))
+                    logger.info("AUDIT LOGIN FOR: %s CLEANING OLD GROUP MEMBERSHIP" % (username,))
                     if hasattr(settings, 'LDAP_IGNORED_LOCAL_GROUPS'):
                         grps = Group.objects.exclude(name__in=settings.LDAP_IGNORED_LOCAL_GROUPS)
                     else:
@@ -242,34 +241,34 @@ class LDAP3ADBackend(object):
                             if 'attributes' in resp and settings.LDAP_GROUP_MEMBER_ATTRIBUTE in resp['attributes'] \
                                     and user_dn in resp['attributes'][settings.LDAP_GROUP_MEMBER_ATTRIBUTE]:
 
-                                logger.info("AUDIT LOGIN FOR: %s AT %s DETECTED IN GROUP %s" %
-                                            (username, datetime.now(), resp['dn']))
+                                logger.info("AUDIT LOGIN FOR: %s DETECTED IN GROUP %s" %
+                                            (username, resp['dn']))
                                 # special super user group
                                 if alter_superuser_membership:
                                     if resp['dn'] in settings.LDAP_SUPERUSER_GROUPS:
                                         usr.is_superuser = True
-                                        logger.info("AUDIT LOGIN FOR: %s AT %s GRANTING ADMIN RIGHTS" %
-                                                    (username, datetime.now()))
+                                        logger.info("AUDIT LOGIN FOR: %s GRANTING ADMIN RIGHTS" %
+                                                    (username,))
                                     else:
-                                        logger.info("AUDIT LOGIN FOR: %s AT %s DENY ADMIN RIGHTS" %
-                                                    (username, datetime.now()))
+                                        logger.info("AUDIT LOGIN FOR: %s DENY ADMIN RIGHTS" %
+                                                    (username,))
                                 # special staff group
                                 if alter_staff_membership:
                                     if resp['dn'] in settings.LDAP_STAFF_GROUPS:
                                         usr.is_staff = True
-                                        logger.info("AUDIT LOGIN FOR: %s AT %s GRANTING STAFF RIGHTS" %
-                                                    (username, datetime.now()))
+                                        logger.info("AUDIT LOGIN FOR: %s GRANTING STAFF RIGHTS" %
+                                                    (username,))
                                     else:
-                                        logger.info("AUDIT LOGIN FOR: %s AT %s DENY STAFF RIGHTS" %
-                                                    (username, datetime.now()))
+                                        logger.info("AUDIT LOGIN FOR: %s DENY STAFF RIGHTS" %
+                                                    (username,))
                                 # other groups membership
                                 for grp in settings.LDAP_GROUPS_MAP.keys():
                                     if resp['dn'] == settings.LDAP_GROUPS_MAP[grp]:
                                         try:
                                             logger.info(grp)
                                             usr.groups.add(Group.objects.get(name=grp))
-                                            logger.info("AUDIT LOGIN FOR: %s AT %s ADDING GROUP %s MEMBERSHIP" %
-                                                        (username, datetime.now(), grp))
+                                            logger.info("AUDIT LOGIN FOR: %s ADDING GROUP %s MEMBERSHIP" %
+                                                        (username, grp))
                                         except ObjectDoesNotExist:
                                             pass
                     usr.save()
@@ -277,16 +276,16 @@ class LDAP3ADBackend(object):
                 con.unbind()
 
                 # if set, apply min group membership
-                logger.info("AUDIT LOGIN FOR: %s AT %s BEFORE MIN GROUP MEMBERSHIP" %
-                            (username, datetime.now()))
+                logger.info("AUDIT LOGIN FOR: %s BEFORE MIN GROUP MEMBERSHIP" %
+                            (username,))
                 if hasattr(settings, 'LDAP_MIN_GROUPS'):
                     for grp in settings.LDAP_MIN_GROUPS:
-                        logger.info("AUDIT LOGIN FOR: %s AT %s MIN GROUP MEMBERSHIP: %s" %
-                                    (username, datetime.now(), grp))
+                        logger.info("AUDIT LOGIN FOR: %s MIN GROUP MEMBERSHIP: %s" %
+                                    (username, grp))
                         try:
                             usr.groups.add(Group.objects.get(name=grp))
-                            logger.info("AUDIT LOGIN FOR: %s AT %s ADDING GROUP %s MIN MEMBERSHIP" %
-                                        (username, datetime.now(), grp))
+                            logger.info("AUDIT LOGIN FOR: %s ADDING GROUP %s MIN MEMBERSHIP" %
+                                        (username, grp))
                         except ObjectDoesNotExist:
                             pass
 


### PR DESCRIPTION
Everytime a user logs in, I see
`RuntimeWarning: DateTimeField received a naive datetime (...) while time zone support is active.`
in Apache logs.
This is because the naive `datetime.datetime.now()` is used to get time. `django.utils.timezone.now()` respects `USE_TZ` setting to produce a naive or timezone-aware time for storing in the database.

Additionally, I removed now() from all logging calls, because time is an essential property of log record.